### PR TITLE
Abstracted package to UPM

### DIFF
--- a/.github/workflows/autotag.yml
+++ b/.github/workflows/autotag.yml
@@ -1,0 +1,16 @@
+name: Create Tag
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: Klemensas/action-autotag@stable
+      with:
+        GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+        package_root: "Assets/EventVisualizer"

--- a/Assets/EventVisualizer/Demo/EventVisualizer.Demo.asmdef
+++ b/Assets/EventVisualizer/Demo/EventVisualizer.Demo.asmdef
@@ -1,0 +1,12 @@
+{
+    "name": "EventVisualizer.Demo",
+    "references": [],
+    "optionalUnityReferences": [],
+    "includePlatforms": [],
+    "excludePlatforms": [],
+    "allowUnsafeCode": false,
+    "overrideReferences": false,
+    "precompiledReferences": [],
+    "autoReferenced": false,
+    "defineConstraints": []
+}

--- a/Assets/EventVisualizer/Demo/EventVisualizer.Demo.asmdef.meta
+++ b/Assets/EventVisualizer/Demo/EventVisualizer.Demo.asmdef.meta
@@ -1,6 +1,6 @@
 fileFormatVersion: 2
-guid: d40c08a65f046aa4ab7131aa0ce74948
-TextScriptImporter:
+guid: 55a8720238c1ce447ab1359e6f37c2a4
+AssemblyDefinitionImporter:
   externalObjects: {}
   userData: 
   assetBundleName: 

--- a/Assets/EventVisualizer/Editor/EventVisualizer.asmdef
+++ b/Assets/EventVisualizer/Editor/EventVisualizer.asmdef
@@ -1,0 +1,14 @@
+{
+    "name": "EventVisualizer",
+    "references": [],
+    "optionalUnityReferences": [],
+    "includePlatforms": [
+        "Editor"
+    ],
+    "excludePlatforms": [],
+    "allowUnsafeCode": false,
+    "overrideReferences": false,
+    "precompiledReferences": [],
+    "autoReferenced": true,
+    "defineConstraints": []
+}

--- a/Assets/EventVisualizer/Editor/EventVisualizer.asmdef.meta
+++ b/Assets/EventVisualizer/Editor/EventVisualizer.asmdef.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 64c2793f320f60e42b03db19f6ed1408
+AssemblyDefinitionImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/EventVisualizer/LICENSE.md
+++ b/Assets/EventVisualizer/LICENSE.md
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) [2020] [Luca Mefisto]
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/Assets/EventVisualizer/LICENSE.md.meta
+++ b/Assets/EventVisualizer/LICENSE.md.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: bd4a495518c2e724eaa17886449e06c6
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/EventVisualizer/ReadMe.md
+++ b/Assets/EventVisualizer/ReadMe.md
@@ -1,13 +1,13 @@
-#EventVisualizer
+# EventVisualizer
 
-##What
+## What
 Have you ever come across a project that abuses linking UnityEvents in the inspector and now you can
 not find who is calling what?
 Event Visualizer is a visual tool that allows you to see all the UnityEvents in a scene at
 a glance and when they are being triggered. It creates a graph in which nodes are gameobjects,
 outputs are any type of UnityEvent (custom ones supported as well!) and inputs are methods.
 
-##How
+## How
 
 - Select ```Windows/Events Graph Editor``` you can open the graph.
 - Select any root gameobject(s) and click on ```Rebuild on selected hierarchy``` to generate a graph
@@ -21,7 +21,7 @@ in order to create a graph starting just in this gameobject or any of its childr
 - From the graph you can also activate the Scene View Graph https://www.youtube.com/watch?v=IhG0LRFLmdo.
 - Check the scene under /Demo 
 
-##Who
+## Who
 - Original idea by SoylentGraham(https://github.com/SoylentGraham)
 - Code by Luca Mefisto(https://github.com/MephestoKhaan) (myself)
 - Inspired by Keijiro Takahashi(https://github.com/keijiro)

--- a/Assets/EventVisualizer/ReadMe.md.meta
+++ b/Assets/EventVisualizer/ReadMe.md.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: b88cef69f4b009449a5c80773ced781d
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/EventVisualizer/package.json
+++ b/Assets/EventVisualizer/package.json
@@ -1,6 +1,6 @@
 {
     "name": "com.mefistofiles.unity-event-visualizer",
-    "version": "1.0.1",
+    "version": "1.4.2",
     "displayName": "Unity Event Visualizer",
     "description": "A graph editor for viewing all UnityEvents at a glance ",
     "unity": "2017.4",

--- a/Assets/EventVisualizer/package.json
+++ b/Assets/EventVisualizer/package.json
@@ -1,0 +1,34 @@
+{
+    "name": "com.mefistofiles.unity-event-visualizer",
+    "version": "1.0.1",
+    "displayName": "Unity Event Visualizer",
+    "description": "A graph editor for viewing all UnityEvents at a glance ",
+    "unity": "2017.4",
+    "unityRelease": "37f1",
+    "keywords": [
+      "unity",
+      "event",
+      "visualizer"
+    ],
+    "homepage": "https://github.com/MephestoKhaan/UnityEventVisualizer/",
+    "bugs": {
+      "url": "https://github.com/MephestoKhaan/UnityEventVisualizer/issues"
+    },
+    "repository": {
+      "type": "git",
+      "url": "ssh://git@github.com:MephestoKhaan/UnityEventVisualizer.git"
+    },
+    "license": "MIT",
+    "author": {
+      "name": "Luca Mefisto",
+      "email": "luca.m.conesa@gmail.com",
+      "url": "http://mefistofiles.com/"
+    },
+    "files": [
+      "*.md",
+      "*.meta",
+      "*.asmdef",
+      "Demo",
+      "Editor"
+    ]
+  }

--- a/Assets/EventVisualizer/package.json.meta
+++ b/Assets/EventVisualizer/package.json.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 6da3ed9fdc162914fad734e70ffcf27d
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
Abstracted the package to work as a UPM.
For this I had to generate asmdef files for both directories, add a License (I added a MIT) and a package.json

---
The idea would be to merge this, and after that add the repository to [OpenUPM](https://openupm.com/) so people can install the package doing `openupm add com.mefistofiles.unity-event-visualizer`.

This PR also closes #14 

I also added a workflow that will automatically tag new releases to match the `package.json` version.